### PR TITLE
Update other useAgentChat clients with ai reponse stream

### DIFF
--- a/src/app/chat-agent-sdk/ChatAgentSDK.tsx
+++ b/src/app/chat-agent-sdk/ChatAgentSDK.tsx
@@ -4,7 +4,9 @@ import { MessageInput } from '../shared/MessageInput'
 import { MessageList } from '../shared/MessageList'
 import { useAgent } from 'agents/react'
 import { useAgentChat } from 'agents/ai-react'
+import { useEffect } from 'react'
 import { ClientOnly } from '../shared/ClientOnly'
+import { type OutgoingMessage } from 'agents/ai-types'
 
 export function ChatAgentSDK() {
   const agent = useAgent({
@@ -12,9 +14,42 @@ export function ChatAgentSDK() {
     name: 'rwsdk-chat-agent-sdk'
   })
 
-  const { messages, input, handleInputChange, handleSubmit, clearHistory } = useAgentChat({
+  const { messages, setMessages, input, handleInputChange, handleSubmit, clearHistory } = useAgentChat({
     agent
   })
+
+  useEffect(() => {
+    console.log('messages effect', messages.length)
+    // update local messages when another client initiates an aiFetch
+    // modeled after agents/src/ai-react.tsx
+    function onMessages(event: MessageEvent) {
+      if (typeof event.data !== 'string') {
+        return
+      }
+      let data: OutgoingMessage
+      try {
+        data = JSON.parse(event.data) as OutgoingMessage
+      } catch (error) {
+        return
+      }
+      switch (data.type) {
+        case 'cf_agent_use_chat_response':
+          console.log('chat response messages', messages.length)
+          console.log('chat response', data.id, data.body, data.done)
+          break
+        case 'cf_agent_chat_messages':
+          console.log('chat messages', data.messages)
+          break
+        case 'cf_agent_chat_clear':
+          console.log('chat clear')
+          break
+      }
+    }
+    agent.addEventListener('message', onMessages)
+    return () => {
+      agent.removeEventListener('message', onMessages)
+    }
+  }, [messages])
 
   return (
     <ChatLayout title="RedwoodSDK Agent SDK Chat">

--- a/src/app/chat-agent-sdk/ChatAgentSDKDO.ts
+++ b/src/app/chat-agent-sdk/ChatAgentSDKDO.ts
@@ -1,25 +1,31 @@
 import { AIChatAgent } from 'agents/ai-chat-agent'
 import { createWorkersAI } from 'workers-ai-provider'
 import { env } from 'cloudflare:workers'
-import { streamText, type StreamTextOnFinishCallback, type ToolSet } from 'ai'
+import { createDataStreamResponse, streamText, type StreamTextOnFinishCallback, type ToolSet } from 'ai'
 
 export class ChatAgentSDKDO extends AIChatAgent<Env> {
   async onChatMessage(onFinish: StreamTextOnFinishCallback<ToolSet>) {
     const workersai = createWorkersAI({ binding: env.AI })
 
-    const stream = streamText({
-      // @ts-expect-error (this 🦙 is not typed in ts)
-      model: workersai('@cf/meta/llama-3.1-8b-instruct-fp8-fast'),
-      messages: [
-        {
-          role: 'system',
-          content: 'You are a helpful and delightful assistant'
-        },
-        ...this.messages
-      ],
-      maxTokens: 4096,
-      onFinish
+    // 
+    const dataStreamResponse = createDataStreamResponse({
+      execute: async (dataStream) => {
+        const result = streamText({
+          // @ts-expect-error (this 🦙 is not typed in ts)
+          model: workersai('@cf/meta/llama-3.1-8b-instruct-fp8-fast'),
+          messages: [
+            {
+              role: 'system',
+              content: 'You are a helpful and delightful assistant'
+            },
+            ...this.messages
+          ],
+          maxTokens: 4096,
+          onFinish
+        })
+        result.mergeIntoDataStream(dataStream)
+      }
     })
-    return stream.toDataStreamResponse()
+    return dataStreamResponse
   }
 }


### PR DESCRIPTION
Attempt to fix #23 (Chat Agent SDK only)

I noticed that the streamed AI response chunks are broadcast, but only used by the client which prompted.
Technically it should be possible to use the chunks to update the messages on other clients as they arrive.

- [x] log events in the browser to understand what's really going on
- [ ] work out how to manage state so that chunks are not applied twice on the prompting client
- [ ] do it
