### PR TITLE
Subagents FTW (part 2)

### DIFF
--- a/src/app/chat-agent-agent/ChatAgentAgentDO.ts
+++ b/src/app/chat-agent-agent/ChatAgentAgentDO.ts
@@ -52,7 +52,11 @@ export class ChatAgentAgentDO extends AIChatAgent<Env> {
         result.mergeIntoDataStream(dataStream)
       }
     })
-
     return dataStreamResponse
+  }
+
+  async getMessages() {
+    console.log('getMessages', this.messages)
+    return this.messages
   }
 }


### PR DESCRIPTION
Continuation of #27

- [x] getAgentMessages built-in tool for named (e.g. main) agent or subagents
- [ ] callSubAgent tool
- [ ] messages UI for tool use (no approval flow required)
- [ ] routes for subagent views in UI
- [ ] demo subagent 
- [ ] demo installable MCP tools

# bonus
- [ ] pubsub or callback for subagents