### PR TITLE
use content Layout for app routes

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -1,6 +1,7 @@
 ---
 title: agents-chat
-siteurl: https://agents-chat.jldec.workers.dev/
+splashimage: bloem.jpg
+siteurl: https://agents-chat.jldec.me/
 description: Co-founder & product engineer 🌳 The Web is for everyone ❤️
 twitter: '@jldec'
 navlinks:
@@ -21,8 +22,6 @@ sociallinks:
     href: mailto:jurgen@jldec.me
     icon: email
 ---
-
-![bloemies](bloem.jpg)
 
 # agents-chat
 Multi-user streaming AI chats built using RedwoodSDK, Cloudflare Agents, and RSCs.

--- a/src/app/contentSource/markdown/get-markdown.ts
+++ b/src/app/contentSource/markdown/get-markdown.ts
@@ -17,7 +17,7 @@ async function filePath(path: string): Promise<string> {
   return `${path}.md`
 }
 
-async function getSourceText(path: string): Promise<string> {
+async function getSourceText(path: string): Promise<string | null> {
   const filepath = await filePath(path)
   let resp: Response
   let source = 'github'
@@ -39,8 +39,8 @@ async function getSourceText(path: string): Promise<string> {
       }
     )
   }
-  if (!resp.ok) throw new Error(`${resp.status} error fetching ${path}`)
   console.log('getMarkdown', source, resp.status)
+  if (!resp.ok) return null
   return await resp.text()
 }
 
@@ -56,6 +56,7 @@ export async function getPageData(path: string, noCache: boolean = false): Promi
   }
 
   const sourceText = await getSourceText(path)
+  if (!sourceText) return null
   const parsedFrontmatter = parseFrontmatter(sourceText)
   const dirData = await getDirData(path, parsedFrontmatter.attrs.sortby)
   const pageData = {

--- a/src/app/contentSource/routes.tsx
+++ b/src/app/contentSource/routes.tsx
@@ -3,7 +3,7 @@ import { getManifest } from './manifest'
 import { getPageData } from './markdown/get-markdown'
 import { getStatic } from './static'
 import { getRedirects } from './redirects'
-import { type PageContext } from './types'
+import { type ContentPageContext } from './types'
 import { type RequestInfo } from 'rwsdk/worker'
 
 export const contentRoutes = async ({ request, ctx }: RequestInfo): Promise<Response | void> => {
@@ -37,7 +37,7 @@ export const contentRoutes = async ({ request, ctx }: RequestInfo): Promise<Resp
     return Response.redirect(url.origin + redirects[pathname].redirect + search, redirects[pathname].status)
   }
   const pagePaths = await getPagePaths()
-  const pageContext: PageContext = {
+  const pageContext: ContentPageContext = {
     pathname,
     siteData: '/' in pagePaths ? (await getPageData('/'))?.attrs : undefined,
     pageData: pathname in pagePaths ? (await getPageData(pathname, noCache)) || undefined : undefined,

--- a/src/app/contentSource/types.ts
+++ b/src/app/contentSource/types.ts
@@ -1,5 +1,5 @@
 // TODO: DirData should be part of PageData
-export type PageContext = {
+export type ContentPageContext = {
   pathname: string
   pageData?: PageData
   siteData?: Frontmatter

--- a/src/app/contentTheme/404.tsx
+++ b/src/app/contentTheme/404.tsx
@@ -1,12 +1,12 @@
 import { requestInfo as r } from 'rwsdk/worker'
-import { Layout } from './Layout'
+import { ContentLayout } from './ContentLayout'
 
 export function NotFound() {
   return (
-    <Layout>
+    <ContentLayout>
       <h1>404</h1>
       <p>Page not found</p>
       <p>{r.request.url}</p>
-    </Layout>
+    </ContentLayout>
   )
 }

--- a/src/app/contentTheme/BlogList.tsx
+++ b/src/app/contentTheme/BlogList.tsx
@@ -1,30 +1,32 @@
 import { requestInfo as r } from 'rwsdk/worker'
 import { Layout } from './Layout'
+import { ContentHtml } from './ContentHtml'
 
 export function BlogList() {
   const pageData = r.ctx.pageContext?.pageData
   return (
     <Layout>
-      <title>{pageData?.attrs.title}</title>
-      <div dangerouslySetInnerHTML={{ __html: pageData?.html ?? '[empty page]' }} />
+      <ContentHtml />
       {pageData?.dir ? (
-        <ul>
-          {pageData.dir.map((d) => {
-            const text = d.attrs?.title ?? d.path
-            const date = d.attrs?.date ?? ''
-            return (
-              <li key={d.path} className="leading-[1.1rem] pb-1">
-                <a
-                  className="group flex items-end gap-4 no-underline hover:transform-none border-b-[1.5px] border-b-transparent hover:border-b-current"
-                  href={d.path}
-                >
-                  <span className="flex-grow">{text}</span>
-                  <span className="hidden sm:block text-transparent group-hover:text-orange-500">{date}</span>
-                </a>
-              </li>
-            )
-          })}
-        </ul>
+        <div className="prose max-w-none mt-4">
+          <ul>
+            {pageData.dir.map((d) => {
+              const text = d.attrs?.title ?? d.path
+              const date = d.attrs?.date ?? ''
+              return (
+                <li key={d.path} className="leading-[1.1rem] pb-1">
+                  <a
+                    className="group flex items-end gap-4 no-underline border-b-[1.5px] border-b-transparent hover:border-b-current"
+                    href={d.path}
+                  >
+                    <span className="flex-grow">{text}</span>
+                    <span className="hidden sm:block text-transparent group-hover:text-orange-500">{date}</span>
+                  </a>
+                </li>
+              )
+            })}
+          </ul>{' '}
+        </div>
       ) : null}
     </Layout>
   )

--- a/src/app/contentTheme/BlogList.tsx
+++ b/src/app/contentTheme/BlogList.tsx
@@ -1,11 +1,11 @@
 import { requestInfo as r } from 'rwsdk/worker'
-import { Layout } from './Layout'
+import { ContentLayout } from './ContentLayout'
 import { ContentHtml } from './ContentHtml'
 
 export function BlogList() {
   const pageData = r.ctx.pageContext?.pageData
   return (
-    <Layout>
+    <ContentLayout>
       <ContentHtml />
       {pageData?.dir ? (
         <div className="prose max-w-none mt-4">
@@ -28,6 +28,6 @@ export function BlogList() {
           </ul>{' '}
         </div>
       ) : null}
-    </Layout>
+    </ContentLayout>
   )
 }

--- a/src/app/contentTheme/BlogPost.tsx
+++ b/src/app/contentTheme/BlogPost.tsx
@@ -1,6 +1,7 @@
 import { requestInfo as r } from 'rwsdk/worker'
 import { Layout } from './Layout'
 import { List, SquareChevronUp, SquareChevronDown } from './icons'
+import { ContentHtml } from './ContentHtml'
 
 function parentPath(path: string) {
   return path.split('/').slice(0, -1).join('/') || '/'
@@ -23,7 +24,7 @@ export function BlogPost() {
 
   return (
     <Layout>
-      <p className="flex">
+      <p className="flex mb-4">
         <span className="flex-grow">{longdate}</span>
         {/* <a
           className="px-[6px] text-gray-400 hover:text-orange-500"
@@ -62,7 +63,7 @@ export function BlogPost() {
           ''
         )}
       </p>
-      <div dangerouslySetInnerHTML={{ __html: pageData?.html ?? '[empty page]' }} />
+      <ContentHtml />
     </Layout>
   )
 }

--- a/src/app/contentTheme/BlogPost.tsx
+++ b/src/app/contentTheme/BlogPost.tsx
@@ -1,5 +1,5 @@
 import { requestInfo as r } from 'rwsdk/worker'
-import { Layout } from './Layout'
+import { ContentLayout } from './ContentLayout'
 import { List, SquareChevronUp, SquareChevronDown } from './icons'
 import { ContentHtml } from './ContentHtml'
 
@@ -23,7 +23,7 @@ export function BlogPost() {
   const longdate = [formatDate(pageData?.attrs?.date)].filter(Boolean).join(' - ')
 
   return (
-    <Layout>
+    <ContentLayout>
       <p className="flex mb-4">
         <span className="flex-grow">{longdate}</span>
         {/* <a
@@ -64,6 +64,6 @@ export function BlogPost() {
         )}
       </p>
       <ContentHtml />
-    </Layout>
+    </ContentLayout>
   )
 }

--- a/src/app/contentTheme/ContentHtml.tsx
+++ b/src/app/contentTheme/ContentHtml.tsx
@@ -1,0 +1,6 @@
+import { requestInfo as r } from 'rwsdk/worker'
+
+export function ContentHtml() {
+  const pageData = r.ctx.pageContext?.pageData
+  return <div className="prose max-w-none" dangerouslySetInnerHTML={{ __html: pageData?.html ?? '[empty page]' }} />
+}

--- a/src/app/contentTheme/ContentLayout.tsx
+++ b/src/app/contentTheme/ContentLayout.tsx
@@ -2,9 +2,9 @@ import { requestInfo as r } from 'rwsdk/worker'
 import { Menu } from './Menu'
 import { Splash } from './Splash'
 
-export function Layout({ children }: { children: React.ReactNode }) {
+export function ContentLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="max-w-3xl m-auto p-3">
+    <div className="max-w-3xl m-auto py-2 md:px-2">
       <title>{'Jürgen Leschner - ' + r.ctx.pageContext?.pageData?.attrs.title || 'jldec.me'}</title>
       <Menu />
       <Splash />

--- a/src/app/contentTheme/Home.tsx
+++ b/src/app/contentTheme/Home.tsx
@@ -1,10 +1,10 @@
-import { Layout } from './Layout'
+import { ContentLayout } from './ContentLayout'
 import { ContentHtml } from './ContentHtml'
 
 export function Home() {
   return (
-    <Layout>
+    <ContentLayout>
       <ContentHtml />
-    </Layout>
+    </ContentLayout>
   )
 }

--- a/src/app/contentTheme/Home.tsx
+++ b/src/app/contentTheme/Home.tsx
@@ -1,11 +1,10 @@
-import { requestInfo as r } from 'rwsdk/worker'
 import { Layout } from './Layout'
+import { ContentHtml } from './ContentHtml'
 
 export function Home() {
-  const pageData = r.ctx.pageContext?.pageData
   return (
     <Layout>
-      <div dangerouslySetInnerHTML={{ __html: pageData?.html ?? '[empty page]' }} />
+      <ContentHtml />
     </Layout>
   )
 }

--- a/src/app/contentTheme/Layout.tsx
+++ b/src/app/contentTheme/Layout.tsx
@@ -4,7 +4,7 @@ import { Splash } from './Splash'
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="prose max-w-3xl m-auto p-3">
+    <div className="max-w-3xl m-auto p-3">
       <title>{'Jürgen Leschner - ' + r.ctx.pageContext?.pageData?.attrs.title || 'jldec.me'}</title>
       <Menu />
       <Splash />

--- a/src/app/contentTheme/Page.tsx
+++ b/src/app/contentTheme/Page.tsx
@@ -1,12 +1,12 @@
 import { requestInfo as r } from 'rwsdk/worker'
 import { Layout } from './Layout'
+import { ContentHtml } from './ContentHtml'
 
-// assumes r.ctx.pageContext is set
 export function Page() {
   const pageData = r.ctx.pageContext?.pageData
   return (
     <Layout>
-      <div dangerouslySetInnerHTML={{ __html: pageData?.html ?? '[empty page]' }} />
+      <ContentHtml />
       {pageData?.dir ? (
         <ul>
           {pageData.dir.map((d) => (

--- a/src/app/contentTheme/Page.tsx
+++ b/src/app/contentTheme/Page.tsx
@@ -1,11 +1,11 @@
 import { requestInfo as r } from 'rwsdk/worker'
-import { Layout } from './Layout'
+import { ContentLayout } from './ContentLayout'
 import { ContentHtml } from './ContentHtml'
 
 export function Page() {
   const pageData = r.ctx.pageContext?.pageData
   return (
-    <Layout>
+    <ContentLayout>
       <ContentHtml />
       {pageData?.dir ? (
         <ul>
@@ -16,6 +16,6 @@ export function Page() {
           ))}
         </ul>
       ) : null}
-    </Layout>
+    </ContentLayout>
   )
 }

--- a/src/app/shared/ChatLayout.tsx
+++ b/src/app/shared/ChatLayout.tsx
@@ -1,16 +1,8 @@
-interface ChatLayoutProps {
-  title: string
-  children: React.ReactNode
-}
-
-export function ChatLayout({ title, children }: ChatLayoutProps) {
+export function ChatLayout({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="text-sm p-2 relative max-w-2xl mx-auto">
-      <a href="/" className="text-blue-600 underline text-base absolute top-0 right-0 pt-4 pr-3">
-        Home
-      </a>
-      <h1 className="text-lg font-bold my-2">{title}</h1>
-      <div className="w-full text-left">{children}</div>
-    </div>
+    <>
+      <h1 className="text-2xl font-bold my-2 px-2">{title}</h1>
+      {children}
+    </>
   )
 }

--- a/src/app/shared/MessageInput.tsx
+++ b/src/app/shared/MessageInput.tsx
@@ -45,7 +45,7 @@ export function MessageInput(props: MessageInputProps | MessageInputPropsAgentSD
     await props.onClear()
   }
   return (
-    <form onSubmit={'onSubmit' in props ? props.onSubmit : submit} className="mt-2 mb-[10vh] flex flex-row gap-2">
+    <form onSubmit={'onSubmit' in props ? props.onSubmit : submit} className="mt-10 px-2 md:px-0 mb-[10vh] flex flex-row gap-2">
       <input
         ref={inputRef}
         onChange={'onChange' in props ? props.onChange : (e) => setInput(e.target.value)}

--- a/src/app/shared/MessageList.tsx
+++ b/src/app/shared/MessageList.tsx
@@ -16,10 +16,10 @@ function messageContent(message: Message | UIMessage): string {
 // No hooks - component can run in both RSC and client
 export function MessageList({ messages }: { messages: Message[] | UIMessage[] }) {
   return (
-    <div id="message-list" className="flex flex-col gap-2">
+    <div id="message-list" className="flex flex-col gap-2 prose max-w-none prose-p:!my-0 my-4">
       {messages.map((m) => (
         <div
-          className={cn('border-gray-200 p-2 prose prose-p:my-2', m.role === 'assistant' ? 'bg-gray-100' : 'bg-white')}
+          className={cn('border-gray-200 p-2 rounded-lg', m.role === 'assistant' ? 'bg-gray-100' : 'bg-white')}
           key={m.id}
           dangerouslySetInnerHTML={{ __html: md.render(messageContent(m)) }}
         />

--- a/src/app/shared/agentsRoute.ts
+++ b/src/app/shared/agentsRoute.ts
@@ -1,0 +1,10 @@
+import { routeAgentRequest } from 'agents'
+import type { RequestInfo } from 'rwsdk/worker'
+import { env } from 'cloudflare:workers'
+
+export async function agentsRoute({ request }: RequestInfo) {
+  const response = await routeAgentRequest(request, env)
+  if (response) {
+    return response
+  }
+}

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -68,7 +68,6 @@ html {
   text-decoration-style: double;
   text-decoration-color: #f97316; /* orange-500 */
   text-decoration-thickness: 1.5px;
-  transform: scale(1.05);
 }
 
 .prose hr {

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1,6 +1,13 @@
 @import 'tailwindcss';
 @plugin "@tailwindcss/typography";
 
+/*
+Monospace typography from presskit
+----------------------------------
+locks everything to 15px
+prose-sm and other overides will not work
+*/
+
 html {
   font-family: monospace;
   font-size: 15px;
@@ -9,10 +16,9 @@ html {
 }
 
 .button {
-  @apply inline-block py-2 px-3 mb-4 font-semibold border-2 border-current no-underline;
+  @apply inline-block py-2 px-3 mb-4 font-semibold rounded-md  border-2 border-current no-underline;
 }
 
-/* Typography styles from presskit */
 .prose {
   line-height: 1.4;
 }

--- a/src/app/time/Time.tsx
+++ b/src/app/time/Time.tsx
@@ -10,9 +10,6 @@ export function Time() {
   return (
     <div className="flex flex-col items-center min-h-screen text-sm">
       <h1 className="text-xl font-bold my-2">RedwoodSDK minimal Time Demo</h1>
-      <a href="/" className="text-blue-600 p-2 underline mb-8 text-base">
-        Home
-      </a>
       <Clock />
       <ClientTimeButton />
       <ServerTimeButton callFetch />

--- a/src/worker.tsx
+++ b/src/worker.tsx
@@ -1,3 +1,4 @@
+import { agentsRoute } from './app/shared/agentsRoute'
 import { cacheInterrupter, cacheResponse } from './lib/cacheInterrupter'
 import { ChatAgent } from './app/chat-agent/ChatAgent'
 import { ChatAgentAgent } from './app/chat-agent-agent/ChatAgentAgent'
@@ -7,17 +8,15 @@ import { ChatRSC } from './app/chat-rsc/ChatRSC'
 import { ChatTinybase } from './app/chat-tinybase/ChatTinybase'
 import { defineApp } from 'rwsdk/worker'
 import { Document } from './app/Document'
-import { echoHandler } from './lib/echo'
 import { env } from 'cloudflare:workers'
-import { render, route } from 'rwsdk/router'
+import { render, route, layout, type LayoutProps } from 'rwsdk/router'
 import { realtimeRoute } from 'rwsdk/realtime/worker'
-import { redirectRoutes } from './lib/redirects'
-import { routeAgentRequest } from 'agents'
 import { Time } from './app/time/Time'
 import { timeApiRoutes } from './app/time/api-routes'
 import { tinybaseApiRoutes } from './app/chat-tinybase/api-routes'
 
-import type { PageContext } from './app/contentSource/types'
+import type { ContentPageContext } from './app/contentSource/types'
+import { ContentLayout } from './app/contentTheme/ContentLayout'
 import { contentRoutes } from './app/contentSource/routes'
 import { contentTheme } from './app/contentTheme/routes'
 
@@ -29,40 +28,34 @@ export { ChatAgentAgentDO } from './app/chat-agent-agent/ChatAgentAgentDO'
 export { TinyBaseDurableObject } from './app/chat-tinybase/tinybaseDO'
 
 export type AppContext = {
-  pageContext?: PageContext
+  pageContext?: ContentPageContext
 }
+
+export const AppLayout = ({ children }: LayoutProps) => <ContentLayout>{children}</ContentLayout>
 
 const app = defineApp([
   realtimeRoute(() => env.REALTIME_DURABLE_OBJECT),
-  render(Document, [
-    // index(Home),
-    route('/chat-rsc', [cacheInterrupter, ChatRSC]),
-    route('/chat-agent', [cacheInterrupter, ChatAgent]),
-    route('/chat-tinybase', [cacheInterrupter, ChatTinybase]),
-    route('/time', [cacheInterrupter, Time])
-  ]),
+  agentsRoute,
   render(
     Document,
-    [
-      route('/chat-agent-sdk', [cacheInterrupter, ChatAgentSDK]),
-      route('/chat-agent-agent', [cacheInterrupter, ChatAgentAgent])
-    ],
-    { ssr: false }
+    layout(AppLayout, [
+      route('/chat-rsc', [cacheInterrupter, contentRoutes, ChatRSC]),
+      route('/chat-agent', [cacheInterrupter, contentRoutes, ChatAgent]),
+      route('/chat-tinybase', [cacheInterrupter, contentRoutes, ChatTinybase]),
+      route('/time', [cacheInterrupter, contentRoutes, Time])
+    ])
   ),
-  async ({ request }) => {
-    const response = await routeAgentRequest(request, env)
-    if (response) {
-      return response
-    }
-  },
+  render(
+    Document,
+    layout(AppLayout, [
+      route('/chat-agent-sdk', [cacheInterrupter, contentRoutes, ChatAgentSDK]),
+      route('/chat-agent-agent', [cacheInterrupter, contentRoutes, ChatAgentAgent])
+    ]),
+    { ssr: false } // useAgentChat doesn't play well with SSR
+  ),
   ...chatAgentApiRoutes,
   ...tinybaseApiRoutes,
   ...timeApiRoutes,
-  ...redirectRoutes([
-    { from: '/chat', to: '/chat-rsc' },
-    { from: '/chat-client', to: '/chat-agent' }
-  ]),
-  route('/echo', echoHandler),
   render(Document, [route('*', [cacheInterrupter, contentRoutes, contentTheme])])
 ])
 


### PR DESCRIPTION
Content layout is server-only, inject into app routes which can be client or server using [rwsdk layout()](https://docs.rwsdk.com/guides/frontend/layouts/).

Cleanup router to make more readable.