### PR TITLE
status 404 when not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "vite dev --force",
     "test": "vitest run",
     "build": "vite build",
-    "preview": "vite preview",
+    "preview": "vite build && vite preview",
     "ship": "vite build && wrangler deploy",
     "types": "wrangler types --include-runtime false --strict-vars false",
     "tail": "wrangler tail"

--- a/src/app/contentTheme/404.tsx
+++ b/src/app/contentTheme/404.tsx
@@ -1,12 +1,16 @@
 import { requestInfo as r } from 'rwsdk/worker'
 import { ContentLayout } from './ContentLayout'
 
+// h1 #id is set to 404 to signal client.tsx not to run initClient
+// See https://github.com/redwoodjs/sdk/issues/568#issuecomment-3038822673
 export function NotFound() {
   return (
     <ContentLayout>
-      <h1>404</h1>
-      <p>Page not found</p>
-      <p>{r.request.url}</p>
+      <div className="prose max-w-none">
+        <h1 id="404">404</h1>
+        <p>Page not found</p>
+        <p>{r.request.url}</p>
+      </div>
     </ContentLayout>
   )
 }

--- a/src/app/contentTheme/contentTheme.tsx
+++ b/src/app/contentTheme/contentTheme.tsx
@@ -1,11 +1,12 @@
-import { type RequestInfo } from 'rwsdk/worker'
+import { type RequestInfo, renderToStream } from 'rwsdk/worker'
+import { Document } from '@/app/Document'
 import { NotFound } from './404'
 import { Page } from './Page'
 import { Home } from './Home'
 import { BlogList } from './BlogList'
 import { BlogPost } from './BlogPost'
 
-export function contentTheme({ ctx }: RequestInfo) {
+export async function contentTheme({ ctx, request }: RequestInfo) {
   if (ctx.pageContext?.pageData) {
     switch (ctx.pageContext.pathname) {
       case '/':
@@ -18,5 +19,12 @@ export function contentTheme({ ctx }: RequestInfo) {
         }
         return <Page />
     }
-  } else return <NotFound />
+  } else {
+    // TODO: replace with requestInfo.status = 404 when available
+    // https://github.com/redwoodjs/sdk/issues/568
+    console.log(`404: ${request.url}`)
+    return new Response(await renderToStream(<NotFound />, { Document }), {
+      status: 404
+    })
+  }
 }

--- a/src/client.tsx
+++ b/src/client.tsx
@@ -13,6 +13,8 @@ switch (window.location.pathname) {
     })
     break
   default:
-    initClient()
+    if (!document.getElementById('404')) {
+      initClient()
+    }
     break
 }


### PR DESCRIPTION
Sends status 404 for routes when not found.

uses `new Response(await renderToStream(<NotFound />, { Document })` as suggested in https://github.com/redwoodjs/sdk/issues/568

This caused an error in initClient() which I work around by not calling initClient on the 404 page. See https://github.com/redwoodjs/sdk/issues/569