### PR TITLE
Error with rwsdk v0.3.2 - dev and build fails - missing swr import "default" importing from react-server.mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "markdown-it-replace-link": "^1.2.2",
     "nanoid": "^5.1.5",
     "reconnecting-websocket": "^4.4.0",
-    "rwsdk": "0.3.2",
+    "rwsdk": "0.3.4",
     "tinybase": "^6.5.2",
     "workers-ai-provider": "^0.7.5",
     "zod": "^3.25.76"


### PR DESCRIPTION
@justinvdm sorry I think rwsdk v0.3.2 is having trouble separating browser vs. server imports.
Could it be that you're not distinguishing those anymore?
The problem does not happen with v0.3.0

This swr default import problem caused a runtime SSR issue before, which was why I prevent SSR for the 2 client components that `import { useAgentChat } from 'agents/ai-react'`.

Unfortunately with v0.3.2 this is now happening at build time.

**repro**: clone this branch, `pnpm install`, `pnpm build` (or `pnpm dev`) 

when fixed, you should be able to `pnpm dev` and open `http://localhost:5173/chat-agent-sdk`

```
> vite build

🔍 Scanning for 'use client' and 'use server' directives...
✅ Scan complete.
error during build:
Error: RWSDK directive scan failed:
Error: Build failed with 3 errors:
node_modules/.pnpm/@ai-sdk+react@1.2.12_react@19.2.0-canary-39cad7af-20250411_zod@3.25.76/node_modules/@ai-sdk/react/dist/index.mjs:184:7: ERROR: No matching export in "node_modules/.pnpm/@ai-sdk+react@1.2.12_react@19.2.0-canary-39cad7af-20250411_zod@3.25.76/node_modules/swr/dist/index/react-server.mjs" for import "default"
node_modules/.pnpm/@ai-sdk+react@1.2.12_react@19.2.0-canary-39cad7af-20250411_zod@3.25.76/node_modules/@ai-sdk/react/dist/index.mjs:563:7: ERROR: No matching export in "node_modules/.pnpm/@ai-sdk+react@1.2.12_react@19.2.0-canary-39cad7af-20250411_zod@3.25.76/node_modules/swr/dist/index/react-server.mjs" for import "default"
node_modules/.pnpm/@ai-sdk+react@1.2.12_react@19.2.0-canary-39cad7af-20250411_zod@3.25.76/node_modules/@ai-sdk/react/dist/index.mjs:708:7: ERROR: No matching export in "node_modules/.pnpm/@ai-sdk+react@1.2.12_react@19.2.0-canary-39cad7af-20250411_zod@3.25.76/node_modules/swr/dist/index/react-server.mjs" for import "default"
    at failureErrorWithLog (/Users/jldec/cloudflare/redwood/agents-chat/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1467:15)
    at /Users/jldec/cloudflare/redwood/agents-chat/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:926:25
    at runOnEndCallbacks (/Users/jldec/cloudflare/redwood/agents-chat/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1307:45)
    at buildResponseToResult (/Users/jldec/cloudflare/redwood/agents-chat/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:924:7)
    at /Users/jldec/cloudflare/redwood/agents-chat/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:951:16
    at responseCallbacks.<computed> (/Users/jldec/cloudflare/redwood/agents-chat/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:603:9)
    at handleIncomingPacket (/Users/jldec/cloudflare/redwood/agents-chat/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:658:12)
    at Socket.readFromStdout (/Users/jldec/cloudflare/redwood/agents-chat/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:581:7)
    at Socket.emit (node:events:518:28)
    at Socket.emit (node:domain:489:12)
    at runDirectivesScan (file:///Users/jldec/cloudflare/redwood/agents-chat/node_modules/.pnpm/rwsdk@0.3.2_rollup@4.50.0_typescript@5.9.2_vite@7.1.4_@types+node@24.3.1_jiti@2.5.1_lig_75ac87fe8d7a437b07095d1658681788/node_modules/rwsdk/dist/vite/runDirectivesScan.mjs:149:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async buildApp (file:///Users/jldec/cloudflare/redwood/agents-chat/node_modules/.pnpm/rwsdk@0.3.2_rollup@4.50.0_typescript@5.9.2_vite@7.1.4_@types+node@24.3.1_jiti@2.5.1_lig_75ac87fe8d7a437b07095d1658681788/node_modules/rwsdk/dist/vite/buildApp.mjs:14:5)
    at async Object.buildApp (file:///Users/jldec/cloudflare/redwood/agents-chat/node_modules/.pnpm/rwsdk@0.3.2_rollup@4.50.0_typescript@5.9.2_vite@7.1.4_@types+node@24.3.1_jiti@2.5.1_lig_75ac87fe8d7a437b07095d1658681788/node_modules/rwsdk/dist/vite/configPlugin.mjs:151:21)
    at async Object.buildApp (file:///Users/jldec/cloudflare/redwood/agents-chat/node_modules/.pnpm/vite@7.1.4_@types+node@24.3.1_jiti@2.5.1_lightningcss@1.30.1_terser@5.44.0/node_modules/vite/dist/node/chunks/dep-C6pp_iVS.js:34605:38)
    at async CAC.<anonymous> (file:///Users/jldec/cloudflare/redwood/agents-chat/node_modules/.pnpm/vite@7.1.4_@types+node@24.3.1_jiti@2.5.1_lightningcss@1.30.1_terser@5.44.0/node_modules/vite/dist/node/cli.js:648:3)
 ELIFECYCLE  Command failed with exit code 1.
```