### PR TITLE
alpha-0 fails on agents sdk routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "markdown-it-replace-link": "^1.2.2",
     "nanoid": "^5.1.5",
     "reconnecting-websocket": "^4.4.0",
-    "rwsdk": "0.3.7",
+    "rwsdk": "1.0.0-alpha.0",
     "tinybase": "^6.6.0",
     "workers-ai-provider": "^2.0.0",
     "zod": "^3.25.76"


### PR DESCRIPTION
agents sdk has imports like agents_ai-react.js which only work in the client.

previously turning off ssr on the client-only routes which do imports from agents/react and agents/ai-react was enough to isolate this code and prevent server-side issues.
 
```ts
import { useAgent } from 'agents/react'
import { useAgentChat } from 'agents/ai-react'
```

As of alpha-0 this no longer appears to be working. I have confirmed that the ssr flag is still working in https://github.com/jldec/rwsdk-no-ssr, but for some reason this is not the case here.

- clone this branch
- pnpm install
- pnpm dev
- navigate to http://localhost:5173/chat-agent-sdk

<img width="915" height="374" alt="Screenshot 2025-09-15 at 20 51 49" src="https://github.com/user-attachments/assets/d8817acb-31be-4fd3-867e-022ffda49da5" />

    