### PR TITLE
alpha.14 Error "new version of the pre-bundle..." on first load

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react-dom": "19.2.0-canary-3fb190f7-20250908",
     "react-server-dom-webpack": "19.2.0-canary-3fb190f7-20250908",
     "reconnecting-websocket": "^4.4.0",
-    "rwsdk": "1.0.0-alpha.9",
+    "rwsdk": "1.0.0-alpha.14",
     "tinybase": "^6.6.1",
     "workers-ai-provider": "^2.0.0",
     "zod": "^3.25.76"


### PR DESCRIPTION
bumped from alpha.9 to alpha.14 and started seeing this error consistently on first page load
Tried clean install and flushing browser cache and it still happens

```
… (rwsdk) Scanning for 'use client' and 'use server' directives...
✔ (rwsdk) Done scanning for 'use client' and 'use server' directives.
o
8:03:08 AM [vite] (worker) ✨ new dependencies optimized: rwsdk/constants
8:03:08 AM [vite] (worker) ✨ optimized dependencies changed. reloading
[vite] program reload

8:03:08 AM [vite] Internal server error: There is a new version of the pre-bundle for "/Users/jldec/cloudflare/redwood/agents-chat/node_modules/.vite/deps_worker/rwsdk_worker.js?v=b4e580dc", a page reload is going to ask for it.
      at CustomModuleRunner.cachedModule (runner-worker/index.js:1231:22)
      at request (runner-worker/index.js:1152:86)
      at null.<anonymous> (/Users/jldec/cloudflare/redwood/agents-chat/src/app/contentSource/markdown/get-markdown.ts:7:31)
      at Object.runInlinedModule (runner-worker/index.js:1342:9)
      at CustomModuleRunner.directRequest (runner-worker/index.js:1206:61)
      at CustomModuleRunner.cachedRequest (runner-worker/index.js:1113:79)
      at null.<anonymous> (/Users/jldec/cloudflare/redwood/agents-chat/src/app/contentSource/markdown/get-dirs.ts:5:31)
      at Object.runInlinedModule (runner-worker/index.js:1342:9)
      at CustomModuleRunner.directRequest (runner-worker/index.js:1206:61)
      at CustomModuleRunner.cachedRequest (runner-worker/index.js:1113:79)
8
```