### PR TITLE
Repro: Uncaught (in promise) ReferenceError: __webpack_require__ is not defined

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react-dom": "19.2.0-canary-3fb190f7-20250908",
     "react-server-dom-webpack": "19.2.0-canary-3fb190f7-20250908",
     "reconnecting-websocket": "^4.4.0",
-    "rwsdk": "1.0.0-alpha.20",
+    "rwsdk": "1.0.0-beta.2",
     "tinybase": "^6.6.1",
     "workers-ai-provider": "^2.0.0",
     "zod": "^3.25.76"


### PR DESCRIPTION
**This applies only to the production build (not dev server)**
Upgrading from rwsdk alpha 20 to beta 2 results in this client-side error on page load.
So far only reproducable with this repo 

### To reproduce
- clone this branch
- pnpm install
- pnpm preview (runs vite build && vite preview)  
- type o to open browser

```
react-server-dom-webpack-client.browser.production.js:112:28
ReferenceError: __webpack_require__ is not defined
```

```
"react-server-dom-webpack": "19.2.0-canary-3fb190f7-20250908",
"rwsdk": "1.0.0-beta.2",
```

<img width="1440" height="808" alt="Screenshot 2025-10-02 at 12 02 36" src="https://github.com/user-attachments/assets/f4c63a41-7c26-4e58-b76a-586d48cd837b" />

