### PR TITLE
Repro Error: 'jsonSchema not initialized' when calling mcp.getAITools()

### DIFF
--- a/src/app/chat-agent-agent/ChatAgentAgentDO.ts
+++ b/src/app/chat-agent-agent/ChatAgentAgentDO.ts
@@ -23,7 +23,7 @@ export class ChatAgentAgentDO extends AIChatAgent<Env> {
     // Collect all tools, including MCP tools
     const allTools = {
       ...agentTools(this),
-      ...(mcpServers.tools.length ? this.mcp.getAITools() : {})
+      ...this.mcp.getAITools() // (mcpServers.tools.length ? this.mcp.getAITools() : {})
     }
     // Prevent recursion - subagents cannot use subagent tools
     Object.keys(allTools).forEach((key) => {


### PR DESCRIPTION
After upgrading to the latest version of the cloudflare agents SDK, I noticed the error below intermittently.
This PR disables the workaround, which avoids calling `this.mcp.getAITools()` on the agent, when there are no MCPs.

### To try to repro
- clone and checkout this branch
- pnpm install
- set OPENAI_API_KEY in .dev.vars
- pnpm dev
- open browser on http://localhost:5173/chat-agent-agent (or click on `6. Agent Agent Chat` on the home page)
- enter prompts: "what is the time", "test", "test 2" 
- if you don't see the error, wait a minute, then try one of the prompts again

```
Chat message request
mcpServers { prompts: [], resources: [], servers: {}, tools: [] }
Error on server: Error: jsonSchema not initialized.
    at MCPClientManager.getAITools (/Users/jldec/cloudflare/redwood/agents-chat/node_modules/.vite/deps_worker/chunk-UBIZWKXI.js:2263:33)
    at ChatAgentAgentDO.onChatMessage (/Users/jldec/cloudflare/redwood/agents-chat/src/app/chat-agent-agent/ChatAgentAgentDO.ts:26:19)
    at /Users/jldec/cloudflare/redwood/agents-chat/node_modules/.vite/deps_worker/agents_ai-chat-agent.js:168:32
Override onError(error) to handle server errors 
```

